### PR TITLE
Fix load analytics command

### DIFF
--- a/ckanext/googleanalytics/commands.py
+++ b/ckanext/googleanalytics/commands.py
@@ -109,7 +109,7 @@ class LoadAnalytics(CkanCommand):
                      (url, count, tracking_date, tracking_type)
                      VALUES (%s, %s, %s, %s);'''
             log.debug("internal_save: SQL %r; %r, %r, %r, %r", sql,
-                      url, count, tracking_date, tracking_type)
+                      url, count, summary_date, tracking_type)
 
             engine.execute(sql, url, count, summary_date, tracking_type)
 

--- a/ckanext/googleanalytics/commands.py
+++ b/ckanext/googleanalytics/commands.py
@@ -11,6 +11,8 @@ import ckan.model as model
 import dbutil
 
 log = logging.getLogger('ckanext.googleanalytics')
+log.setLevel(logging.DEBUG)
+
 PACKAGE_URL = '/dataset/'  # XXX get from routes...
 DEFAULT_RESOURCE_URL_TAG = '/downloads/'
 


### PR DESCRIPTION
Same fixes for two different branches. Check PR: https://github.com/datopian/ckanext-googleanalytics/pull/3

* fix package id updates in the tracking_summary table (internal save)
* fix package and resource id updates in the tracking_downloads table (downloads save)
* fix the number of arguments checking when calling internal save

