### PR TITLE
Adds digital analytics script

### DIFF
--- a/ckanext/googleanalytics/templates/googleanalytics/snippets/googleanalytics_header.html
+++ b/ckanext/googleanalytics/templates/googleanalytics/snippets/googleanalytics_header.html
@@ -12,3 +12,5 @@
   ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
 </script>
+
+<script async type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=ED"></script>


### PR DESCRIPTION
I'm not sure how to test if this is working properly, but [this](https://www2.ed.gov/web-guidance/stats/dap-code.html) doesn't list any other steps to get it working.